### PR TITLE
NXP-27878: Update nuxeo.jsf.version before mvn set version call

### DIFF
--- a/Jenkinsfiles/build-status.groovy
+++ b/Jenkinsfiles/build-status.groovy
@@ -94,8 +94,8 @@ void updateVersion() {
     New version: ${NEW_VERSION}
   """
   sh """
-    mvn -nsu versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
     perl -i -pe 's|<nuxeo.jsf.version>${CURRENT_VERSION}</nuxeo.jsf.version>|<nuxeo.jsf.version>${NEW_VERSION}</nuxeo.jsf.version>|' pom.xml
+    mvn -nsu versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
   """
 }
 

--- a/Jenkinsfiles/build.groovy
+++ b/Jenkinsfiles/build.groovy
@@ -63,8 +63,8 @@ void updateVersion() {
   """
   echo "MAVEN_OPTS=$MAVEN_OPTS"
   sh """
-    mvn -nsu versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
     perl -i -pe 's|<nuxeo.jsf.version>${CURRENT_VERSION}</nuxeo.jsf.version>|<nuxeo.jsf.version>${NEW_VERSION}</nuxeo.jsf.version>|' pom.xml
+    mvn -nsu versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
   """
 }
 


### PR DESCRIPTION
We need to update `nuxeo.jsf.version` before calling maven otherwise maven wants to resolve jsf code/ftests/packages module with previous version.